### PR TITLE
Mention the realm when logging that someone has started a new quest

### DIFF
--- a/www/templates/event.html
+++ b/www/templates/event.html
@@ -1,7 +1,7 @@
 <div class="event-header">
   <% if (type == 'add-quest') { %>
     <i class="icon-plus"></i>
-    <%= partial.user({ realm: realm, login: author }) %> started a new quest:
+    <%= partial.user({ realm: realm, login: author }) %> started a new <a href="/realm/<%- realm %>"><%- realm %></a> quest:
 
   <% } else if (type == 'add-comment' && (comment.type == undefined || comment.type == 'text')) { %>
     <div class="event-header">


### PR DESCRIPTION
Instead of saying:

> Fred has started a new quest.

Say:

> Fred has started a new **chaos** quest.

I haven't actually tested that this works, but it _looks_ right from look at examples in your templates ;-)
