### PR TITLE
Using session_secure

### DIFF
--- a/cookbooks/questhub/templates/default/dancer-config.yml.erb
+++ b/cookbooks/questhub/templates/default/dancer-config.yml.erb
@@ -5,6 +5,7 @@ template: "template_toolkit"
 
 session: "MongoDB"
 session_expires: "10d"
+session_secure: 1
 mongodb_session_db: "play"
 mongodb_session_coll: "sessions"
 


### PR DESCRIPTION
https://metacpan.org/pod/Dancer::Config#session_secure

For now the cookie does not have secure flag:
![screen shot 2014-03-10 at 19 18 12](https://f.cloud.github.com/assets/47263/2375033/41c66f3e-a867-11e3-81c4-6b809bac1014.png)
