### PR TITLE
update a couple of versions across cookbooks

### DIFF
--- a/cookbooks/questhub/recipes/default.rb
+++ b/cookbooks/questhub/recipes/default.rb
@@ -44,7 +44,7 @@ package 'libgd2-noxpm'
 package 'libgd2-xpm-dev'
 cpan_module 'Image::Resize'
 
-cpan_module 'T/TO/TOBYINK/Type-Tiny-0.042.tar.gz'
+cpan_module 'T/TO/TOBYINK/Type-Tiny-1.000004.tar.gz'
 
 directory '/data' # logs
 

--- a/cookbooks/questhub/recipes/dev.rb
+++ b/cookbooks/questhub/recipes/dev.rb
@@ -36,10 +36,8 @@ include_recipe "phantomjs"
 # used by build_static.pl
 cpan_module "IPC::System::Simple"
 
-# not using gem_package - it fails for some reason
-execute "install-SASS" do
-    not_if "which sass"
-    command "gem install sass --prerelease" # --prerelease is dangerous, but gives us source maps (until 3.3.0 officially releases)
+gem_package 'sass' do
+  version '3.4.5'
 end
 gem_package 'rb-inotify' do
   version '0.9'

--- a/cookbooks/questhub/recipes/frontend.rb
+++ b/cookbooks/questhub/recipes/frontend.rb
@@ -13,7 +13,7 @@ package 'nginx-full' do
     action :remove
 end
 package 'nginx' do
-    version "1.6.0-1~precise"
+    version "1.6.2-1~precise"
 end
 
 directory '/data' # logs


### PR DESCRIPTION
At least that got me going, I was stuck with non-provisioned machine otherwise:
- `Type::Tiny` -- @tobyink removed pre-1.000000 versions from CPAN, used the most recent one;
- I got some weird error trying to install `sass`. Didn't dig deep, changing to gem installation worked fine;
- `apt` wasn't able to find `1.6.0-1~precise`, changed to which was available

Cheers!
