### PR TITLE
Vagrantfile patch

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,8 @@ Vagrant::Config.run do |config|
 
   # Install make
   config.vm.provision :shell, :inline => "apt-get install make"
+  # Install fixed version of mixlib-shellout gem (chef-solo fails with 1.6.0)
+  config.vm.provision :shell, :inline => "gem install mixlib-shellout --version 1.4.0"
   # Upgrade chef
   config.vm.provision :shell, :inline => "gem install chef --version 10.16.4 --no-rdoc --no-ri --conservative"
   # Enable and configure the chef solo provisioner

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,8 @@ Vagrant::Config.run do |config|
   # all code should use /play, because we have no vagrant in production environment, and it would be weird to keep /vagrant folder there
   config.vm.share_folder "play", "/play", "."
 
+  # Install make
+  config.vm.provision :shell, :inline => "apt-get install make"
   # Upgrade chef
   config.vm.provision :shell, :inline => "gem install chef --version 10.16.4 --no-rdoc --no-ri --conservative"
   # Enable and configure the chef solo provisioner


### PR DESCRIPTION
Two tweaks for Vagrantfile here:
* for some reason Vagrant image was missing `make`, so the whole provisioning was failing quite early. I've added simple fix for that. There probably is a better way to insure beforehand this essential tool is in place, but `apt-get install` just does the right thing for me;
* far more serious showstopper -- `chef-solo` failure:
```
==> default: Successfully installed mixlib-config-2.1.0
==> default: Successfully installed mixlib-shellout-1.6.0
==> default: Successfully installed chef-10.16.4
==> default: Successfully installed systemu-2.6.4
==> default: Successfully installed ffi-1.9.6
==> default: Successfully installed libyajl2-1.1.0
==> default: Successfully installed ffi-yajl-1.2.0
==> default: Successfully installed wmi-lite-1.0.0
==> default: Successfully installed rdoc-4.1.2
==> default: 9 gems installed
==> default: Running provisioner: chef_solo...
Generating chef JSON and uploading...
==> default: Running chef-solo...
==> default: stdin: is not a tty
==> default: /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require': /opt/vagrant_
ruby/lib/ruby/gems/1.8/gems/mixlib-shellout-1.6.0/lib/mixlib/shellout/unix.rb:294: syntax error, unexpected tSYMBEG, expecti
ng tAMPER (SyntaxError)
==> default: ..._of?(Array) ? exec(*command, :close_others=>true) : exec(com...
==> default:                               ^
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/mixlib-shellout-1.6.0/lib/mixlib/shellout.rb:36
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/shell_out.rb:1
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/mixin/shell_out.rb:18
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/resource/conditional.rb:19
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/resource.rb:24
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/resource/file.rb:20
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/provider/file.rb:21
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/provider/cookbook_file.rb:20
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/providers.rb:20
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef.rb:25
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/../lib/chef/application/solo.rb:19
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `gem_original_require'
==> default:    from /opt/vagrant_ruby/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:54:in `require'
==> default:    from /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.16.4/bin/chef-solo:23
==> default:    from /opt/vagrant_ruby/bin/chef-solo:19:in `load'
==> default:    from /opt/vagrant_ruby/bin/chef-solo:19
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```
Looks like `mixlib-shellout` 1.6.0 (released on October 7) doesn't play well with `chef-solo` and Questhub is [not the only one](https://github.com/ynniv/opengenera/issues/9) being bitten by this already.
My suggestion is to stick with previous stable `mixlib-shellout` (1.4.0) for now.